### PR TITLE
Main readonly mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -217,24 +217,36 @@ span>img.w-full {
 
 @media print {
     .bg-primary {
-        visibility: collapse!important
+        visibility: collapse !important;
+    }
+    /* User message content also uses bg-primary — re-show it with legible text */
+    .prose.bg-primary {
+        visibility: visible !important;
+        background-color: transparent !important;
+        color: black !important;
     }
     .bottom-0,.justify-center,.powered-by {
-        display: none!important
+        display: none !important;
     }
     .bg-card {
-        visibility: visible!important;
-        position: absolute!important;
-        top: 0!important;
-        left: 0!important;
-        color: #f00 !important;
-        border: none!important;
-        box-shadow: none!important
+        visibility: visible !important;
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+        border: none !important;
+        box-shadow: none !important;
     }
     .overflow-hidden {
         overflow: visible !important;
     }
     .h-full {
         height: unset !important;
+    }
+    pre, code, pre *, code * {
+        white-space: pre-wrap !important;
+        word-break: break-all !important;
+        overflow-wrap: break-word !important;
+        overflow: visible !important;
+        max-width: 100% !important;
     }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,19 +216,25 @@ span>img.w-full {
 }
 
 @media print {
-  .bg-primary {
-    visibility: collapse !important;
-  }
-  .justify-center, .bottom-0, .powered-by {
-    display: none !important;
-  }
-  .bg-card {
-    visibility: visible !important;
-    position: absolute !important;
-    top: 0 !important;
-    left: 0 !important;
-    color: #000;
-    border: none !important;
-    box-shadow: none !important;
-  }
+    .bg-primary {
+        visibility: collapse!important
+    }
+    .bottom-0,.justify-center,.powered-by {
+        display: none!important
+    }
+    .bg-card {
+        visibility: visible!important;
+        position: absolute!important;
+        top: 0!important;
+        left: 0!important;
+        color: #f00 !important;
+        border: none!important;
+        box-shadow: none!important
+    }
+    .overflow-hidden {
+        overflow: visible !important;
+    }
+    .h-full {
+        height: unset !important;
+    }
 }

--- a/src/features/chat/chat-menu/new-chat.tsx
+++ b/src/features/chat/chat-menu/new-chat.tsx
@@ -24,6 +24,8 @@ export const NewChat = () => {
       className="gap-2 rounded-full w-[40px] h-[40px] p-1 text-primary"
       variant={"outline"}
       onClick={() => startNewChat()}
+      disabled
+      title="New chats are disabled — this site is in read-only mode"
     >
       <PlusCircle size={40} strokeWidth={1.2} />
     </Button>

--- a/src/features/chat/chat-ui/chat-context.tsx
+++ b/src/features/chat/chat-ui/chat-context.tsx
@@ -26,6 +26,7 @@ interface ChatContextProps extends UseChatHelpers {
   id: string;
   setChatBody: (body: PromptGPTBody) => void;
   chatBody: PromptGPTBody;
+  chatThreadName: string;
   fileState: FileState;
   onChatTypeChange: (value: ChatType) => void;
   onConversationStyleChange: (value: ConversationStyle) => void;
@@ -101,6 +102,7 @@ export const ChatProvider: FC<Prop> = (props) => {
         ...response,
         setChatBody,
         chatBody,
+        chatThreadName: props.chatThread.name,
         onChatTypeChange,
         onConversationStyleChange,
         fileState,

--- a/src/features/chat/chat-ui/chat-empty-state/start-new-chat.tsx
+++ b/src/features/chat/chat-ui/chat-empty-state/start-new-chat.tsx
@@ -12,7 +12,7 @@ export const StartNewChat: FC<Prop> = (props) => {
       <div className="col-span-2 gap-5 flex flex-col flex-1">
         <img src="/ai-icon.png" className="w-36" />
       </div>
-      <Card className="col-span-3 flex flex-col gap-5 p-5 bg-amber-50 border-amber-400 border-2">
+      <Card className="col-span-3 flex flex-col gap-5 p-5 bg-amber-50 border-amber-400 border-2 dark:bg-amber-900 dark:border-amber-500 dark:text-amber-50">
         <Typography variant="h4" className="text-primary">
           {AI_NAME}
         </Typography>

--- a/src/features/chat/chat-ui/chat-empty-state/start-new-chat.tsx
+++ b/src/features/chat/chat-ui/chat-empty-state/start-new-chat.tsx
@@ -12,7 +12,7 @@ export const StartNewChat: FC<Prop> = (props) => {
       <div className="col-span-2 gap-5 flex flex-col flex-1">
         <img src="/ai-icon.png" className="w-36" />
       </div>
-      <Card className="col-span-3 flex flex-col gap-5 p-5 ">
+      <Card className="col-span-3 flex flex-col gap-5 p-5 bg-amber-50 border-amber-400 border-2">
         <Typography variant="h4" className="text-primary">
           {AI_NAME}
         </Typography>

--- a/src/features/chat/chat-ui/chat-header.tsx
+++ b/src/features/chat/chat-ui/chat-header.tsx
@@ -1,3 +1,8 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { AI_NAME } from "@/features/theme/customise";
+import { Download } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { FC } from "react";
 import { useChatContext } from "./chat-context";
 import { ChatStyleSelector } from "./chat-empty-state/chat-style-selector";
@@ -5,13 +10,59 @@ import { ChatTypeSelector } from "./chat-empty-state/chat-type-selector";
 
 interface Prop {}
 
-export const ChatHeader: FC<Prop> = (props) => {
-  const { chatBody } = useChatContext();
+export const ChatHeader: FC<Prop> = () => {
+  const { chatBody, messages, chatThreadName } = useChatContext();
+  const { data: session } = useSession();
+
+  const handleDownload = () => {
+    const userName = session?.user?.name ?? "User";
+    const lines: string[] = [
+      `# ${chatThreadName || "Chat Conversation"}`,
+      "",
+      `**Exported:** ${new Date().toLocaleDateString()}`,
+      "",
+      "---",
+      "",
+    ];
+
+    for (const msg of messages) {
+      const role = msg.role === "user" ? userName : AI_NAME;
+      lines.push(`## ${role}`);
+      lines.push("");
+      lines.push(msg.content);
+      lines.push("");
+      lines.push("---");
+      lines.push("");
+    }
+
+    const blob = new Blob([lines.join("\n")], {
+      type: "text/markdown;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${(chatThreadName || "conversation")
+      .replace(/[^a-z0-9]/gi, "-")
+      .toLowerCase()}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex gap-2">
+      <div className="flex gap-2 items-center">
         <ChatTypeSelector disable={true} />
         <ChatStyleSelector disable={true} />
+        {messages.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDownload}
+            title="Download conversation as Markdown"
+          >
+            <Download size={16} />
+          </Button>
+        )}
       </div>
       <div className="flex gap-2 h-2">
         <p className="text-xs">{chatBody.chatOverFileName}</p>

--- a/src/features/chat/chat-ui/chat-input/chat-input.tsx
+++ b/src/features/chat/chat-ui/chat-input/chat-input.tsx
@@ -44,20 +44,21 @@ const ChatInput: FC<Props> = (props) => {
         <Textarea
           rows={rows}
           value={input}
-          placeholder="Send a message"
+          placeholder="This site is in read-only mode. New messages are disabled."
           className="min-h-fit bg-background shadow-sm resize-none py-4 pr-[80px]"
           onKeyUp={onKeyUp}
           onKeyDown={onKeyDown}
           onChange={onChange}
+          disabled
         ></Textarea>
         <div className="absolute right-0 bottom-0 px-8 flex items-end h-full mr-2 mb-4">
-          {speechEnabled && <Microphone disabled={isLoading} />}
+          {speechEnabled && <Microphone disabled={true} />}
           <Button
             size="icon"
             type="submit"
             variant={"ghost"}
             ref={buttonRef}
-            disabled={isLoading}
+            disabled={true}
           >
             {isLoading ? (
               <Loader className="animate-spin" size={16} />

--- a/src/features/theme/customise.ts
+++ b/src/features/theme/customise.ts
@@ -1,16 +1,10 @@
 export const AI_NAME = "WashU ChatGPT";
 export let HOME_MESSAGE = `
-<strong>gpt.wustl.edu is upgrading!</strong> We are transitioning to a new Secure WashU AI platform at <a target="_blank" href="https://askwashu.wustl.edu">askwashu.wustl.edu</a>. Please update your bookmarks.
-<br/>
-This site will become <strong>read-only on June 1, 2026</strong> and will be <strong>retired on July 1, 2026</strong>.
+<strong>gpt.wustl.edu is now in Read-Only mode.</strong> New conversations are no longer available. Your chat history will remain accessible until <strong>July 1, 2026</strong>.
 <br/><br/>
-This fully secure sandbox is compliant for use with sensitive data, including information protected under HIPAA and FERPA.
+<strong>Export your chats before July 1:</strong> Open any past chat, then use your browser's <strong>Print</strong> option and choose <strong>Save as PDF</strong> to save a copy.
 <br/><br/>
-Refrain from participating in harmful or offensive activities as per <a target="_blank" href="https://wustl.edu/about/compliance-policies/">university policies</a>.
-All interactions are logged and linked to the user's WUSTL Key account.
-Learn more at <a target="_blank" href="https://genai.wustl.edu/chatgpt">genai.wustl.edu/chatgpt</a>.
-<br/><br/>
-Open a new prompt window by selecting the plus sign below.
+After July 1, this site will be replaced by <a target="_blank" href="https://askwashu.wustl.edu">askwashu.wustl.edu</a> — our new Secure WashU AI platform. Please update your bookmarks.
 `;
 
 export const FEEDBACK_LINK = "mailto:aiquestions@wustl.edu?subject=gpt.wustl.edu%20Feedback";

--- a/src/features/theme/customise.ts
+++ b/src/features/theme/customise.ts
@@ -1,10 +1,10 @@
 export const AI_NAME = "WashU ChatGPT";
 export let HOME_MESSAGE = `
-<strong>gpt.wustl.edu is now in Read-Only mode.</strong> New conversations are no longer available. Your chat history will remain accessible until <strong>July 1, 2026</strong>.
+<strong>gpt.wustl.edu is now in Read-Only mode.</strong>New conversations are no longer available. Your chat history will remain accessible until <strong>July 1, 2026</strong>.
 <br/><br/>
 <strong>Export your chats before July 1:</strong> Open any past chat, then use your browser's <strong>Print</strong> option and choose <strong>Save as PDF</strong> to save a copy.
 <br/><br/>
-After July 1, this site will be replaced by <a target="_blank" href="https://askwashu.wustl.edu">askwashu.wustl.edu</a> — our new Secure WashU AI platform. Please update your bookmarks.
+As of June 1, this site has been replaced by <a target="_blank" href="https://askwashu.wustl.edu">askwashu.wustl.edu</a> — our new Secure WashU AI platform. Please update your bookmarks.
 `;
 
 export const FEEDBACK_LINK = "mailto:aiquestions@wustl.edu?subject=gpt.wustl.edu%20Feedback";


### PR DESCRIPTION
This pull request updates the chat application to enforce a read-only mode, preventing new messages and chats, and introduces improvements to chat export and print functionality. It also updates user messaging and visual cues to reflect the new status.

Read-only mode enforcement and UI updates:

* Disabled the "New Chat" button and updated its tooltip to indicate that new chats are not allowed in read-only mode (`src/features/chat/chat-menu/new-chat.tsx`).
* Disabled the chat input, microphone, and send button, with a placeholder explaining that new messages are disabled (`src/features/chat/chat-ui/chat-input/chat-input.tsx`).
* Updated the home message to clearly state the site is now in read-only mode, removed references to starting new chats, and added instructions for exporting chats before retirement (`src/features/theme/customise.ts`).

Export and print enhancements:

* Added a "Download conversation as Markdown" button to the chat header, allowing users to export their chat history easily (`src/features/chat/chat-ui/chat-header.tsx`).
* Improved print styles to ensure chat content is legible and formatted correctly when saving or printing, including code blocks and user messages (`src/app/globals.css`).

Visual and context improvements:

* Updated the empty chat state card to use a distinct color scheme, making the read-only status visually clear (`src/features/chat/chat-ui/chat-empty-state/start-new-chat.tsx`).
* Passed the chat thread name through context for use in exports and headers (`src/features/chat/chat-ui/chat-context.tsx`). [[1]](diffhunk://#diff-0477e0de85c6a9a74d8cb6c86ad2eb7a481936d489aeff8313298ef0673eed5eR29) [[2]](diffhunk://#diff-0477e0de85c6a9a74d8cb6c86ad2eb7a481936d489aeff8313298ef0673eed5eR105)